### PR TITLE
修复项目图标上传的BUG

### DIFF
--- a/controllers/BookController.go
+++ b/controllers/BookController.go
@@ -340,7 +340,8 @@ func (c *BookController) UploadCover() {
 	fileName := "cover_" + strconv.FormatInt(time.Now().UnixNano(), 16)
 
 	//附件路径按照项目组织
-	filePath := filepath.Join("uploads", book.Identify, "images", fileName+ext)
+// 	filePath := filepath.Join("uploads", book.Identify, "images", fileName+ext)
+	filePath := filepath.Join(conf.WorkingDirectory, "uploads", book.Identify, "images", fileName+ext)
 
 	path := filepath.Dir(filePath)
 

--- a/graphics/copy.go
+++ b/graphics/copy.go
@@ -18,6 +18,8 @@ func ImageCopy(src image.Image, x, y, w, h int) (image.Image, error) {
 		subImg = rgbImg.SubImage(image.Rect(x, y, x+w, y+h)).(*image.RGBA) //图片裁剪x0 y0 x1 y1
 	} else if rgbImg, ok := src.(*image.NRGBA); ok {
 		subImg = rgbImg.SubImage(image.Rect(x, y, x+w, y+h)).(*image.NRGBA) //图片裁剪x0 y0 x1 y1
+	} else if rgbImg, ok := src.(*image.Paletted); ok {
+		subImg = rgbImg.SubImage(image.Rect(x, y, x+w, y+h)).(*image.Paletted) //图片裁剪x0 y0 x1 y1
 	} else {
 
 		return subImg, errors.New("图片解码失败")


### PR DESCRIPTION
1.BookController.go中344行，拼接上传图片保存路径时未拼接working directory
2.graphics目录下copy.go文件11行，ImageCopy方法增加image.Paletted类型的处理