### PR TITLE
fix #776: 修复在mysql8.0中由于member关键词导致系统无法正常使用的异常

### DIFF
--- a/models/BookModel.go
+++ b/models/BookModel.go
@@ -541,7 +541,7 @@ WHERE book.privately_owned = 0 or rel.role_id >=0 or team.role_id >=0`
 		if err != nil {
 			return
 		}
-		sql2 := `SELECT book.*,rel1.*,member.account AS create_name,member.real_name FROM md_books AS book
+		sql2 := `SELECT book.*,rel1.*,mdmb.account AS create_name,mdmb.real_name FROM md_books AS book
   LEFT JOIN md_relationship AS rel ON rel.book_id = book.book_id AND rel.member_id = ?
   left join (select book_id,min(role_id) AS role_id
              from (select book_id,role_id
@@ -549,7 +549,7 @@ WHERE book.privately_owned = 0 or rel.role_id >=0 or team.role_id >=0`
                      left join md_team_member as mtm on mtm.team_id=mtr.team_id and mtm.member_id=? order by role_id desc )
 as t group by book_id) as team on team.book_id=book.book_id
   LEFT JOIN md_relationship AS rel1 ON rel1.book_id = book.book_id AND rel1.role_id = 0
-  LEFT JOIN md_members AS member ON rel1.member_id = member.member_id
+  LEFT JOIN md_members AS mdmb ON rel1.member_id = mdmb.member_id
 WHERE book.privately_owned = 0 or rel.role_id >=0 or team.role_id >=0 ORDER BY order_index desc,book.book_id DESC LIMIT ?,?`
 
 		_, err = o.Raw(sql2, memberId, memberId, offset, pageSize).QueryRows(&books)
@@ -563,9 +563,9 @@ WHERE book.privately_owned = 0 or rel.role_id >=0 or team.role_id >=0 ORDER BY o
 		}
 		totalCount = int(count)
 
-		sql := `SELECT book.*,rel.*,member.account AS create_name,member.real_name FROM md_books AS book
+		sql := `SELECT book.*,rel.*,mdmb.account AS create_name,mdmb.real_name FROM md_books AS book
 			LEFT JOIN md_relationship AS rel ON rel.book_id = book.book_id AND rel.role_id = 0
-			LEFT JOIN md_members AS member ON rel.member_id = member.member_id
+			LEFT JOIN md_members AS mdmb ON rel.member_id = mdmb.member_id
 			WHERE book.privately_owned = 0 ORDER BY order_index DESC ,book.book_id DESC LIMIT ?,?`
 
 		_, err = o.Raw(sql, offset, pageSize).QueryRows(&books)
@@ -595,14 +595,14 @@ WHERE (relationship_id > 0 OR book.privately_owned = 0 or team.team_member_id > 
 		if err != nil {
 			return
 		}
-		sql2 := `SELECT book.*,rel1.*,member.account AS create_name FROM md_books AS book
+		sql2 := `SELECT book.*,rel1.*,mdmb.account AS create_name FROM md_books AS book
 			LEFT JOIN md_relationship AS rel ON rel.book_id = book.book_id AND rel.member_id = ?
 			left join (select * from (select book_id,team_member_id,role_id
                    	from md_team_relationship as mtr
 					left join md_team_member as mtm on mtm.team_id=mtr.team_id and mtm.member_id=? order by role_id desc )as t group by t.role_id,t.team_member_id,t.book_id) as team 
 					on team.book_id = book.book_id
 			LEFT JOIN md_relationship AS rel1 ON rel1.book_id = book.book_id AND rel1.role_id = 0
-			LEFT JOIN md_members AS member ON rel1.member_id = member.member_id
+			LEFT JOIN md_members AS mdmb ON rel1.member_id = mdmb.member_id
 			WHERE (rel.relationship_id > 0 OR book.privately_owned = 0 or team.team_member_id > 0) 
 			AND book.label LIKE ? ORDER BY order_index DESC ,book.book_id DESC LIMIT ?,?`
 
@@ -619,9 +619,9 @@ WHERE (relationship_id > 0 OR book.privately_owned = 0 or team.team_member_id > 
 		}
 		totalCount = int(count)
 
-		sql := `SELECT book.*,rel.*,member.account AS create_name FROM md_books AS book
+		sql := `SELECT book.*,rel.*,mdmb.account AS create_name FROM md_books AS book
 			LEFT JOIN md_relationship AS rel ON rel.book_id = book.book_id AND rel.role_id = 0
-			LEFT JOIN md_members AS member ON rel.member_id = member.member_id
+			LEFT JOIN md_members AS mdmb ON rel.member_id = mdmb.member_id
 			WHERE book.privately_owned = 0 AND book.label LIKE ? ORDER BY order_index DESC ,book.book_id DESC LIMIT ?,?`
 
 		_, err = o.Raw(sql, keyword, offset, pageSize).QueryRows(&books)

--- a/models/DocumentSearchResult.go
+++ b/models/DocumentSearchResult.go
@@ -53,12 +53,12 @@ FROM (
          book.identify  AS book_identify,
          book.book_name,
          rel.member_id,
-         member.account AS author,
+         mdmb.account AS author,
          'document'     AS search_type
        FROM md_documents AS doc
          LEFT JOIN md_books AS book ON doc.book_id = book.book_id
          LEFT JOIN md_relationship AS rel ON book.book_id = rel.book_id AND rel.role_id = 0
-         LEFT JOIN md_members AS member ON rel.member_id = member.member_id
+         LEFT JOIN md_members AS mdmb ON rel.member_id = mdmb.member_id
        WHERE book.privately_owned = 0 AND (doc.document_name LIKE ? OR doc.release LIKE ?)
      UNION ALL
 SELECT
@@ -71,11 +71,11 @@ SELECT
   book.identify  AS book_identify,
   book.book_name,
   rel.member_id,
-  member.account AS author,
+  mdmb.account AS author,
   'book'     AS search_type
 FROM  md_books AS book
        LEFT JOIN md_relationship AS rel ON book.book_id = rel.book_id AND rel.role_id = 0
-       LEFT JOIN md_members AS member ON rel.member_id = member.member_id
+       LEFT JOIN md_members AS mdmb ON rel.member_id = mdmb.member_id
 WHERE book.privately_owned = 0 AND (book.book_name LIKE ? OR book.description LIKE ?)
 
        UNION ALL
@@ -89,10 +89,10 @@ WHERE book.privately_owned = 0 AND (book.book_name LIKE ? OR book.description LI
          blog.blog_identify,
          blog.blog_title as book_name,
          blog.member_id,
-         member.account,
+         mdmb.account,
          'blog' AS search_type
        FROM md_blogs AS blog
-         LEFT JOIN md_members AS member ON blog.member_id = member.member_id
+         LEFT JOIN md_members AS mdmb ON blog.member_id = mdmb.member_id
        WHERE blog.blog_status = 'public' AND (blog.blog_release LIKE ? OR blog.blog_title LIKE ?)
      ) AS union_table
 ORDER BY create_time DESC
@@ -156,12 +156,12 @@ FROM (
          book.identify  AS book_identify,
          book.book_name,
          rel.member_id,
-         member.account AS author,
+         mdmb.account AS author,
          'document'     AS search_type
        FROM md_documents AS doc
          LEFT JOIN md_books AS book ON doc.book_id = book.book_id
          LEFT JOIN md_relationship AS rel ON book.book_id = rel.book_id AND rel.role_id = 0
-         LEFT JOIN md_members AS member ON rel.member_id = member.member_id
+         LEFT JOIN md_members AS mdmb ON rel.member_id = mdmb.member_id
          LEFT JOIN md_relationship AS rel1 ON doc.book_id = rel1.book_id AND rel1.member_id = ?
          LEFT JOIN (SELECT *
                     FROM (SELECT
@@ -187,11 +187,11 @@ FROM (
          book.identify  AS book_identify,
          book.book_name,
          rel.member_id,
-         member.account AS author,
+         mdmb.account AS author,
          'book'     AS search_type
        FROM md_books AS book
          LEFT JOIN md_relationship AS rel ON book.book_id = rel.book_id AND rel.role_id = 0
-         LEFT JOIN md_members AS member ON rel.member_id = member.member_id
+         LEFT JOIN md_members AS mdmb ON rel.member_id = mdmb.member_id
          LEFT JOIN md_relationship AS rel1 ON book.book_id = rel1.book_id AND rel1.member_id = ?
          LEFT JOIN (SELECT *
                     FROM (SELECT
@@ -216,10 +216,10 @@ FROM (
          blog.blog_identify  AS book_identify,
          blog.blog_title as book_name,
          blog.member_id,
-         member.account,
+         mdmb.account,
          'blog' AS search_type
        FROM md_blogs AS blog
-         LEFT JOIN md_members AS member ON blog.member_id = member.member_id
+         LEFT JOIN md_members AS mdmb ON blog.member_id = mdmb.member_id
        WHERE (blog.blog_status = 'public' OR blog.member_id = ?) AND blog.blog_type = 0 AND
              (blog.blog_release LIKE ? OR blog.blog_title LIKE ?)
      ) AS union_table

--- a/models/Itemsets.go
+++ b/models/Itemsets.go
@@ -236,7 +236,7 @@ WHERE book.item_id = ? AND (book.privately_owned = 0 or rel.role_id >= 0 or team
 			logs.Error("查询项目空间时出错 ->", key, err)
 			return
 		}
-		sql2 := `SELECT book.*,rel1.*,member.account AS create_name FROM md_books AS book
+		sql2 := `SELECT book.*,rel1.*,mdmb.account AS create_name FROM md_books AS book
 			LEFT JOIN md_relationship AS rel ON rel.book_id = book.book_id AND rel.member_id = ?
 			left join (select book_id,min(role_id) as role_id from (select book_id,role_id
                    	from md_team_relationship as mtr
@@ -244,7 +244,7 @@ WHERE book.item_id = ? AND (book.privately_owned = 0 or rel.role_id >= 0 or team
 as t group by book_id) as team 
 					on team.book_id = book.book_id
 			LEFT JOIN md_relationship AS rel1 ON rel1.book_id = book.book_id AND rel1.role_id = 0
-			LEFT JOIN md_members AS member ON rel1.member_id = member.member_id
+			LEFT JOIN md_members AS mdmb ON rel1.member_id = mdmb.member_id
 			WHERE book.item_id = ? AND (book.privately_owned = 0 or rel.role_id >= 0 or team.role_id >= 0) 
 			ORDER BY order_index desc,book.book_id DESC LIMIT ?,?`
 
@@ -261,9 +261,9 @@ as t group by book_id) as team
 		}
 		totalCount = int(count)
 
-		sql := `SELECT book.*,rel.*,member.account AS create_name FROM md_books AS book
+		sql := `SELECT book.*,rel.*,mdmb.account AS create_name FROM md_books AS book
 			LEFT JOIN md_relationship AS rel ON rel.book_id = book.book_id AND rel.role_id = 0
-			LEFT JOIN md_members AS member ON rel.member_id = member.member_id
+			LEFT JOIN md_members AS mdmb ON rel.member_id = mdmb.member_id
 			WHERE book.item_id = ? AND book.privately_owned = 0 ORDER BY order_index desc,book.book_id DESC LIMIT ?,?`
 
 		_, err = o.Raw(sql, item.ItemId, offset, pageSize).QueryRows(&books)

--- a/models/MemberResult.go
+++ b/models/MemberResult.go
@@ -72,9 +72,9 @@ func (m *MemberRelationshipResult) FindForUsersByBookId(lang string, bookId, pag
 
 	var members []*MemberRelationshipResult
 
-	sql1 := "SELECT * FROM md_relationship AS rel LEFT JOIN md_members as member ON rel.member_id = member.member_id WHERE rel.book_id = ? ORDER BY rel.relationship_id DESC  LIMIT ?,?"
+	sql1 := "SELECT * FROM md_relationship AS rel LEFT JOIN md_members as mdmb ON rel.member_id = mdmb.member_id WHERE rel.book_id = ? ORDER BY rel.relationship_id DESC  LIMIT ?,?"
 
-	sql2 := "SELECT count(*) AS total_count FROM md_relationship AS rel LEFT JOIN md_members as member ON rel.member_id = member.member_id WHERE rel.book_id = ?"
+	sql2 := "SELECT count(*) AS total_count FROM md_relationship AS rel LEFT JOIN md_members as mdmb ON rel.member_id = mdmb.member_id WHERE rel.book_id = ?"
 
 	var total_count int
 

--- a/models/TeamMember.go
+++ b/models/TeamMember.go
@@ -213,11 +213,11 @@ func (m *TeamMember) FindNotJoinMemberByAccount(teamId int, account string, limi
 	}
 	o := orm.NewOrm()
 
-	sql := `select member.member_id,member.account,member.real_name,team.team_member_id
-from md_members as member 
-  left join md_team_member as team on team.team_id = ? and member.member_id = team.member_id
-  where member.account like ? or member.real_name like ? AND team_member_id IS NULL
-  order by member.member_id desc 
+	sql := `select mdmb.member_id,mdmb.account,mdmb.real_name,team.team_member_id
+from md_members as mdmb 
+  left join md_team_member as team on team.team_id = ? and mdmb.member_id = team.member_id
+  where mdmb.account like ? or mdmb.real_name like ? AND team_member_id IS NULL
+  order by mdmb.member_id desc 
 limit ?;`
 
 	members := make([]*Member, 0)

--- a/models/comment_result.go
+++ b/models/comment_result.go
@@ -16,10 +16,10 @@ func (m *CommentResult) FindForDocumentToPager(doc_id, page_index, page_size int
 SELECT
   comment.* ,
   parent.* ,
-  member.account AS author,
+  mdmb.account AS author,
   p_member.account AS reply_account
 FROM md_comments AS comment
-  LEFT JOIN md_members AS member ON comment.member_id = member.member_id
+  LEFT JOIN md_members AS mdmb ON comment.member_id = mdmb.member_id
   LEFT JOIN md_comments AS parent ON comment.parent_id = parent.comment_id
   LEFT JOIN md_members AS p_member ON p_member.member_id = parent.member_id
 


### PR DESCRIPTION
issue描述见：https://github.com/mindoc-org/mindoc/issues/776

mysql8.0中member是关键词，在sql中有大量的 `AS member` 需要加反单引号，或者改写其他alias 