### PR TITLE
初始化日志模块时应先重置beego默认的logger

### DIFF
--- a/commands/command.go
+++ b/commands/command.go
@@ -123,6 +123,7 @@ func RegisterModel() {
 // RegisterLogger 注册日志
 func RegisterLogger(log string) {
 
+	logs.Reset()
 	logs.SetLogFuncCall(true)
 	_ = logs.SetLogger("console")
 	logs.EnableFuncCallDepth(true)


### PR DESCRIPTION
在引入beego时,框架已经预先创建了一个默认配置的logger:
```go
func assignConfig(ac config.Configer) error {
	parseConfigForV1(ac)

	err := ac.Unmarshaler("", BConfig)
	if err != nil {
		_, _ = fmt.Fprintln(os.Stderr, fmt.Sprintf("Unmarshaler config file to BConfig failed. "+
			"And if you are working on v1.x config file, please ignore this, err: %s", err))
		return err
	}

	// init log
	logs.Reset()
	for adaptor, cfg := range BConfig.Log.Outputs {
		err := logs.SetLogger(adaptor, cfg)
		if err != nil {
			fmt.Fprintln(os.Stderr, fmt.Sprintf("%s with the config %q got err:%s", adaptor, cfg, err.Error()))
			return err
		}
	}
	logs.SetLogFuncCall(BConfig.Log.FileLineNum)
	return nil
}
```

该默认配置的logger为`Debug`级别,可能会输出较多冗余信息,并且目前的console初始化实际上于默认的console的日志输出是冲突的,此处应该返回的错误由于被忽略用户无法感知:`_ = logs.SetLogger("console")`

如果要在此显式的设置`console`的日志打印的话,应该先将默认的logger配置清除