### PR TITLE
修复代码库读取缓存数据不高亮的问题

### DIFF
--- a/static/js/kancloud.js
+++ b/static/js/kancloud.js
@@ -178,6 +178,7 @@ function loadDocument($url, $id, $callback) {
                 }
                 renderPage(data);
 
+                loadCopySnippets();
                 events.trigger('article.open', { $url: $url, $id: $id });
 
                 return false;


### PR DESCRIPTION
修复2个菜单都包含代码块时，来回点击2个菜单不高亮的bug