### PR TITLE
修复python代码库异步请求获取数据的时候高亮显示问题

### DIFF
--- a/static/js/kancloud.js
+++ b/static/js/kancloud.js
@@ -221,7 +221,7 @@ function loadDocument($url, $id, $callback) {
 function initHighlighting() {
     try {
         $('pre,pre.ql-syntax').each(function (i, block) {
-            if ($(this).hasClass('prettyprinted')) {
+            if ($(this).hasClass('prettyprinted') || $(this).hasClass('hljs')) {
                 return;
             }
             hljs.highlightBlock(block);

--- a/static/js/kancloud.js
+++ b/static/js/kancloud.js
@@ -178,6 +178,7 @@ function loadDocument($url, $id, $callback) {
                 }
                 renderPage(data);
 
+                loadCopySnippets();
                 events.trigger('article.open', { $url: $url, $id: $id });
 
                 return false;


### PR DESCRIPTION
重复来回点几个包含python代码块的菜单可重现这个问题