### PR TITLE
fix: 优化cherry-markdown快捷键 ctrl+s进行保存

### DIFF
--- a/static/js/cherry_markdown.js
+++ b/static/js/cherry_markdown.js
@@ -637,6 +637,13 @@ $(function () {
         }
         $("#documentTemplateModal").modal('hide');
     });
+
+    document.addEventListener('keydown', function(event) {
+        if (event.ctrlKey && event.key === 's') {
+            event.preventDefault();
+            saveDocument(true, null);
+        }
+    });
 });
 
 function myFileUpload(file, callback) {


### PR DESCRIPTION
fix: 优化cherry-markdown快捷键 ctrl+s进行保存