### PR TITLE
修复PostgreSQL数据库下，添加项目成员和全文搜索时发生的SQL语法兼容性错误

### DIFF
--- a/models/DocumentSearchResult.go
+++ b/models/DocumentSearchResult.go
@@ -36,6 +36,15 @@ func need_escape(keyword string) bool {
 	return false
 }
 
+func escape_name(name string) string {
+	dbadapter, _ := web.AppConfig.String("db_adapter")
+	ch := "`"
+	if strings.EqualFold(dbadapter, "postgres") {
+		ch = `"`
+	}
+	return fmt.Sprintf("%s%s%s", ch, name, ch)
+}
+
 func NewDocumentSearchResult() *DocumentSearchResult {
 	return &DocumentSearchResult{}
 }
@@ -294,7 +303,7 @@ WHERE (book.privately_owned = 0 OR rel1.relationship_id > 0 or team.team_member_
 func (m *DocumentSearchResult) SearchDocument(keyword string, bookId int) (docs []*DocumentSearchResult, err error) {
 	o := orm.NewOrm()
 
-	sql := `SELECT * FROM md_documents WHERE book_id = ? AND (document_name LIKE ? OR "release" LIKE ?) `
+	sql := fmt.Sprintf("SELECT * FROM md_documents WHERE book_id = ? AND (document_name LIKE ? OR %s LIKE ?) ", escape_name("release"))
 	keyword = "%" + keyword + "%"
 
 	_need_escape := need_escape(keyword)
@@ -313,7 +322,7 @@ func (m *DocumentSearchResult) SearchDocument(keyword string, bookId int) (docs 
 func (m *DocumentSearchResult) SearchAllDocument(keyword string) (docs []*DocumentSearchResult, err error) {
 	o := orm.NewOrm()
 
-	sql := `SELECT * FROM md_documents WHERE (document_name LIKE ? OR "release" LIKE ?) `
+	sql := fmt.Sprintf("SELECT * FROM md_documents WHERE (document_name LIKE ? OR %s LIKE ?) ", escape_name("release"))
 	keyword = "%" + keyword + "%"
 
 	_need_escape := need_escape(keyword)

--- a/models/DocumentSearchResult.go
+++ b/models/DocumentSearchResult.go
@@ -294,7 +294,7 @@ WHERE (book.privately_owned = 0 OR rel1.relationship_id > 0 or team.team_member_
 func (m *DocumentSearchResult) SearchDocument(keyword string, bookId int) (docs []*DocumentSearchResult, err error) {
 	o := orm.NewOrm()
 
-	sql := "SELECT * FROM md_documents WHERE book_id = ? AND (document_name LIKE ? OR `release` LIKE ?) "
+	sql := `SELECT * FROM md_documents WHERE book_id = ? AND (document_name LIKE ? OR "release" LIKE ?) `
 	keyword = "%" + keyword + "%"
 
 	_need_escape := need_escape(keyword)
@@ -304,7 +304,6 @@ func (m *DocumentSearchResult) SearchDocument(keyword string, bookId int) (docs 
 		}
 		return sql
 	}
-
 	_, err = o.Raw(escape_sql(sql), bookId, keyword, keyword).QueryRows(&docs)
 
 	return
@@ -314,7 +313,7 @@ func (m *DocumentSearchResult) SearchDocument(keyword string, bookId int) (docs 
 func (m *DocumentSearchResult) SearchAllDocument(keyword string) (docs []*DocumentSearchResult, err error) {
 	o := orm.NewOrm()
 
-	sql := "SELECT * FROM md_documents WHERE (document_name LIKE ? OR `release` LIKE ?) "
+	sql := `SELECT * FROM md_documents WHERE (document_name LIKE ? OR "release" LIKE ?) `
 	keyword = "%" + keyword + "%"
 
 	_need_escape := need_escape(keyword)

--- a/models/DocumentSearchResult.go
+++ b/models/DocumentSearchResult.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 	"time"

--- a/models/MemberResult.go
+++ b/models/MemberResult.go
@@ -115,7 +115,7 @@ func (m *MemberRelationshipResult) FindNotJoinUsersByAccount(bookId, limit int, 
 func (m *MemberRelationshipResult) FindNotJoinUsersByAccountOrRealName(bookId, limit int, keyWord string) ([]*Member, error) {
 	o := orm.NewOrm()
 
-	sql := "SELECT m.* FROM md_members as m LEFT JOIN md_relationship as rel ON rel.member_id = m.member_id AND rel.book_id = ? WHERE rel.relationship_id IS NULL AND (m.real_name LIKE ? OR m.account LIKE ?) LIMIT 0,?;"
+	sql := "SELECT m.* FROM md_members as m LEFT JOIN md_relationship as rel ON rel.member_id = m.member_id AND rel.book_id = ? WHERE rel.relationship_id IS NULL AND (m.real_name LIKE ? OR m.account LIKE ?) LIMIT ? OFFSET 0;"
 
 	var members []*Member
 


### PR DESCRIPTION
## 问题

1. 添加项目成员，在账户输入框，输入账户名称，搜索不到用户。
2. 全文搜索时，查找不到可正常匹配的文章。

## 排查

数据库使用 `PostgreSQL`，版本为 ` v15.8`。应为数据库的SQL语法不兼容导致的问题。

1. 添加项目成员：查看网络请求，发现返回报错：`pq: 不支持 LIMIT #,# 语法`
2. 全文搜索：接口 `/docs/odoo_dev/search` 报错 `{"errcode":6002,"message":"搜索结果错误"}`

## 解决

1. 使用标准的SQL写法，`LIMIT 10 OFFSET 0`，以代替简写形式的 `LIMIT 0,10`  SQL语句，使其更具兼容性。
2. 数据表字段使用双引号代替反引号， 即 `OR "release" LIKE ?` 代替 ```OR `release` LIKE ?```  语句，使其更具兼容性。
