### PR TITLE
fix bug #1017:在函数开头添加输入元素检测，当焦点在输入框、textarea、select 或可编辑元素中时，直接返回不执行快捷键操作

### DIFF
--- a/static/js/kancloud.js
+++ b/static/js/kancloud.js
@@ -242,6 +242,16 @@ function initHighlighting() {
 }
 
 function handleEvent(event) {
+    // 如果焦点在输入框、textarea或可编辑元素中，不执行快捷键操作
+    var target = event.target;
+    var tagName = target.tagName.toLowerCase();
+    var isInputElement = tagName === 'input' || tagName === 'textarea' || tagName === 'select';
+    var isContentEditable = target.isContentEditable || target.contentEditable === 'true';
+    
+    if (isInputElement || isContentEditable) {
+        return;
+    }
+    
     switch (event.keyCode) {
         case 70: // ctrl + f 打开搜索面板 并获取焦点
             $(".navg-item[data-mode='search']").click();


### PR DESCRIPTION
<img width="289" height="121" alt="image" src="https://github.com/user-attachments/assets/3480689d-2ca0-4a5b-9620-904bac2ee8a5" />
